### PR TITLE
 Making code Dockstore compatible

### DIFF
--- a/Dockstore.json
+++ b/Dockstore.json
@@ -1,0 +1,18 @@
+{
+  "reference": {
+    "path": "http://hgwdev.cse.ucsc.edu/~jeltje/public_data/genome.fa.gz",
+    "class": "File"
+  },
+  "normal": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143_BL.bam",
+    "class": "File"
+  },
+  "tumor": {
+    "path": "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143.bam",
+    "class": "File"
+  },
+  "mutations": {
+    "path": "/tmp/mutect.vcf",
+    "class": "File"
+  }
+}

--- a/mutect.cwl
+++ b/mutect.cwl
@@ -1,79 +1,81 @@
 cwlVersion: v1.0
 class: CommandLineTool
-label: MuTect
+
+doc: "Mutect 1.1.5"
+
+hints:
+  DockerRequirement:
+    dockerPull: quay.io/opengenomics/mutect
+
 baseCommand: ['python', '/opt/mutect.py']
-requirements:
-  - class: "DockerRequirement"
-    dockerImageId: "mutect:1.1.5"
+
 inputs:
-  - id: "#tumor"
+  tumor:
     type: File
     inputBinding:
       prefix: --input_file:tumor
-    secondaryFiles:
-      - .bai
-  - id: "#normal"
+  normal:
     type: File
     inputBinding:
       prefix: --input_file:normal
-    secondaryFiles:
-      - .bai
-  - id: "#reference"
+  reference:
     type: File
     inputBinding:
       prefix: --reference_sequence
-    secondaryFiles:
-      - .fai
-      - ^.dict
-  - id: "#cosmic"
-    type: File
+  cosmic:
+    type: File?
     inputBinding:
       prefix: --cosmic
-  - id: "#dbsnp"
-    type: File
+  dbsnp:
+    type: File?
     inputBinding:
       prefix: --dbsnp
     secondaryFiles: .tbi
-  - id: "#tumor_lod"
-    type: float
+  tumor_lod:
+    type: float?
     default: 6.3
     inputBinding:
       prefix: --tumor_lod
-  - id: "#initial_tumor_lod"
-    type: float
+  initial_tumor_lod:
+    type: float?
     default: 4.0
     inputBinding:
       prefix: --initial_tumor_lod
-  - id: "#out"
-    type: string
+  ncpus:
+    type: int?
+    inputBinding:
+      position: 2
+      prefix: --ncpus
+  out:
+    type: string?
     default: call_stats.txt
     inputBinding:
       prefix: --out
-  - id: "#coverage_file"
-    type: string
+  coverage_file:
+    type: string?
     default: coverage.wig.txt
     inputBinding:
       prefix: --coverage_file
-  - id: "#vcf"
-    type: string
+  vcf:
+    type: string?
     default: mutations.vcf
     inputBinding:
       prefix: --vcf
 
 outputs:
-  - id: "#coverage"
+  coverage:
     type: File
     outputBinding:
       glob: $(inputs.coverage_file)
 
 
-  - id: "#call_stats"
+  call_stats:
     type: File
     outputBinding:
       glob: $(inputs.out)
 
         
-  - id: "#mutations"
+  mutations:
     type: File
     outputBinding:
       glob: $(inputs.vcf)

--- a/mutect.py
+++ b/mutect.py
@@ -13,7 +13,7 @@ from string import Template
 from multiprocessing import Pool
 
 def gunzip(infile, outfile):
-    cmd = (' ').join(['zcat', infile])
+    cmd = ' '.join(['zcat', infile])
     with open(outfile, 'w') as outF:
         p = subprocess.Popen(cmd, shell=True, stdout=outF, stderr=subprocess.PIPE)
     stdout,stderr =  p.communicate()

--- a/mutect.py
+++ b/mutect.py
@@ -9,16 +9,17 @@ import tempfile
 import vcf
 import argparse
 import logging
-import gzip
 from string import Template
 from multiprocessing import Pool
 
 def gunzip(infile, outfile):
-    inF = gzip.GzipFile(infile, 'rb')
-    s = inF.read()
-    inF.close()
-    with open(outfile, 'wb') as outF:
-        outF.write(s)
+    cmd = (' ').join(['zcat', infile])
+    with open(outfile, 'w') as outF:
+        p = subprocess.Popen(cmd, shell=True, stdout=outF, stderr=subprocess.PIPE)
+    stdout,stderr =  p.communicate()
+    if len(stderr):
+        print "unzip command failed:", stderr
+        raise Exception("unzip failed")
 
 def fai_chunk(path, blocksize):
     seq_map = {}


### PR DESCRIPTION
This PR includes the following changes:

- upgrade cwl to v1.0 and rename to `cwl` to make compatible with Dockstore
- add test input `json` file with publicly available data
- add option to input gzipped genome
- change default docker container to quay.io